### PR TITLE
Bazel: fix opam sanity check dep version

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -23,7 +23,7 @@ git_repository(
 )
 load("@obazl_rules_opam//opam:bootstrap.bzl", "opam_configure")
 load("//bzl:opam.bzl", "opam")
-opam_configure(opam = opam)
+opam_configure(opam = opam, switch = "mina-0.1.0")
 
 ############### Bootstrap OCaml Rules ###############
 git_repository(

--- a/bzl/opam.bzl
+++ b/bzl/opam.bzl
@@ -1,14 +1,22 @@
+PACKAGES = {
+    "base": ["v0.12.0"],
+    "ocaml-compiler-libs": ["v0.11.0", ["compiler-libs.common"]],
+    "ppx_expect": ["v0.12.0", ["ppx_expect.collector"]],
+    "ppx_inline_test": ["v0.12.0", ["ppx_inline_test.runtime-lib"]],
+    "ppxlib": ["0.8.1"],
+    "stdio": ["v0.12.0"],
+}
+
 opam = struct(
-    opam_version = "2.0",
-    packages = {
-        "base": "v0.12.0",
-        "ocaml-compiler-libs": "v0.11.0",
-        "compiler-libs.common": "[distributed with Ocaml]", # "v0.11.0",
-        "ppx_expect": "v0.12.0",
-        "ppx_expect.collector": "v0.12.0",
-        "ppx_inline_test": "v0.12.0",
-        "ppx_inline_test.runtime-lib": "v0.12.0",
-        "ppxlib": "0.8.1",
-        "stdio": "v0.12.0",
+    version = "2.0",
+    switches = {
+        "mina-0.1.0": struct(
+            compiler = "4.07.1",
+            packages = PACKAGES
+        ),
+        "4.07.1": struct(
+            compiler = "4.07.1",
+            packages = PACKAGES
+        )
     }
 )

--- a/bzl/opam.bzl
+++ b/bzl/opam.bzl
@@ -3,7 +3,7 @@ opam = struct(
     packages = {
         "base": "v0.12.0",
         "ocaml-compiler-libs": "v0.11.0",
-        "compiler-libs.common": "v0.11.0",
+        "compiler-libs.common": "[distributed with Ocaml]", # "v0.11.0",
         "ppx_expect": "v0.12.0",
         "ppx_expect.collector": "v0.12.0",
         "ppx_inline_test": "v0.12.0",


### PR DESCRIPTION
OBazl now verifies versions, but some deps, like `compiler-libs.common`, are not included in `opam list` output. For them the "version" must come from `ocamlfind list`.