### PR TITLE
Merge tag v0.13.0 from janestreet

### DIFF
--- a/README-MinaProtocol.md
+++ b/README-MinaProtocol.md
@@ -1,0 +1,9 @@
+# Changes for MinaProtocol
+
+`ppx_optcomp` was forked from `janestreet/ppx_optcomp` at tag
+`v0.12-preview.120.18+252`. A number of changes were made
+atop that, including support for injecting imported values into
+OCaml code, relative import locations, and support for compilation
+with Bazel.
+
+For OCaml 4.11.2, the Jane Street code at v0.13.0 was merged.

--- a/ppx_optcomp.opam
+++ b/ppx_optcomp.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "v0.13.0"
 maintainer: "opensource@janestreet.com"
 authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/ppx_optcomp"
@@ -10,11 +11,11 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.2"}
-  "base"
-  "stdio"
-  "dune"   {build & >= "1.5.1"}
-  "ppxlib" {>= "0.4.0"}
+  "ocaml"  {>= "4.04.2"}
+  "base"   {>= "v0.13" & < "v0.14"}
+  "stdio"  {>= "v0.13" & < "v0.14"}
+  "dune"   {>= "1.5.1"}
+  "ppxlib" {>= "0.9.0"}
 ]
 synopsis: "Optional compilation for OCaml"
 description: "

--- a/src/ppx_optcomp.ml
+++ b/src/ppx_optcomp.ml
@@ -426,11 +426,11 @@ end = struct
 
   let attr_mapper ~to_loc ~to_attrs ~replace_attrs ~env item =
     let loc = to_loc item in
-    let is_our_attribute ({ txt; _}, _) = Token.Directive.matches txt ~expected:"if" in
+    let is_our_attribute { attr_name = { txt; _}; _ } = Token.Directive.matches txt ~expected:"if" in
     let our_as, other_as = List.partition_tf (to_attrs item) ~f:is_our_attribute in
     match our_as with
     | [] -> Some item
-    | [({ loc; _}, payload) as our_a] ->
+    | [{ attr_name = { loc; _}; attr_payload = payload; attr_loc = _; } as our_a] ->
       Attribute.mark_as_handled_manually our_a;
       begin match Interpreter.eval env (get_expr ~loc payload) with
       | Bool b -> if b then Some (replace_attrs item other_as) else None

--- a/src/token.ml
+++ b/src/token.ml
@@ -16,21 +16,21 @@ module Directive = struct
      compiler will make this faster than string equality. *)
   let of_string_opt s =
     match s with
-    | "optcomp.if"              | "if"              -> Some If
-    | "optcomp.else"            | "else"            -> Some Else
-    | "optcomp.elif"            | "elif"            -> Some Elif
-    | "optcomp.endif"           | "endif"           -> Some Endif
-    | "optcomp.ifdef"           | "ifdef"           -> Some Ifdef
-    | "optcomp.ifndef"          | "ifndef"          -> Some Ifndef
-    | "optcomp.define"          | "define"          -> Some Define
-    | "optcomp.undef"           | "undef"           -> Some Undef
-    | "optcomp.error"           | "error"           -> Some Error
-    | "optcomp.warning"         | "warning"         -> Some Warning
-    | "optcomp.import"          | "import"          -> Some Import
+    | "optcomp.if"              | "if"       -> Some If
+    | "optcomp.else"            | "else"     -> Some Else
+    | "optcomp.elif"            | "elif"     -> Some Elif
+    | "optcomp.endif"           | "endif"    -> Some Endif
+    | "optcomp.ifdef"           | "ifdef"    -> Some Ifdef
+    | "optcomp.ifndef"          | "ifndef"   -> Some Ifndef
+    | "optcomp.define"          | "define"   -> Some Define
+    | "optcomp.undef"           | "undef"    -> Some Undef
+    | "optcomp.error"                        -> Some Error
+    | "optcomp.warning"         | "warning"  -> Some Warning
+    | "optcomp.import"          | "import"   -> Some Import
     | "optcomp.import_absolute" | "import_absolute" -> Some Import_absolute
     | "optcomp.inject"          | "inject"          -> Some Inject
-    | "optcomp.elifdef"         | "elifdef"         -> Some Elifdef
-    | "optcomp.elifndef"        | "elifndef"        -> Some Elifndef
+    | "optcomp.elifdef"         | "elifdef"  -> Some Elifdef
+    | "optcomp.elifndef"        | "elifndef" -> Some Elifndef
     | _ -> None
 end
 

--- a/test/errors.mlt
+++ b/test/errors.mlt
@@ -10,7 +10,7 @@ let x = 3
 
 end
 [%%expect{|
-Line _, characters 4-8:
+Line _, characters _-_:
 Error: optcomp: second else clause.
 |}]
 
@@ -26,7 +26,7 @@ let x = 3
 
 end
 [%%expect{|
-Line _, characters 4-8:
+Line _, characters _-_:
 Error: optcomp: elif after else clause.
 |}]
 
@@ -37,7 +37,7 @@ module Test_unterminated_if = struct
 
 end
 [%%expect{|
-Line _, characters 4-6:
+Line _, characters _-_:
 Error: optcomp: unterminated if
 |}]
 
@@ -47,7 +47,7 @@ module Test_import_nonexistent = struct
 
 end
 [%%expect{|
-Line _, characters 4-10:
+Line _, characters _-_:
 Error: optcomp: cannot open imported file: ./non_existent_file.h: ./non_existent_file.h: No such file or directory
 |}]
 

--- a/test/examples.mlt
+++ b/test/examples.mlt
@@ -8,7 +8,7 @@ module Test_simple_if = struct
   let x = "BAD"
   [%% endif]
 
-  let _ = printf "%s" x
+  let () = printf "%s" x
 end
 [%%expect{| OK |}]
 
@@ -24,7 +24,7 @@ module Test_comments = struct
   *)
   [%% endif]
 
-  let _ = printf "%s" x
+  let () = printf "%s" x
 
 end
 [%%expect{| OK |}]
@@ -43,7 +43,7 @@ module Test_nested_if = struct
   [%% endif]
   let y = "OK2"
 
-  let _ = printf "%s %s" x y
+  let () = printf "%s %s" x y
 end
 [%%expect{| OK1 OK2 |}]
 
@@ -66,7 +66,7 @@ module Test_defined = struct
   let y = "OK2"
   [%% endif ]
 
-  let _ = printf "%s %s" x y
+  let () = printf "%s %s" x y
 end
 [%%expect{| OK1 OK2 |}]
 
@@ -76,7 +76,7 @@ module Test_error_simple = struct
   [%% error "Big ooooooops."]
 end
 [%%expect{|
-Line _, characters 6-11:
+Line _, characters _-_:
 Error: Big ooooooops.
 File "examples.mlt", line 74, characters 6-13::
 Warning Ooops.
@@ -102,7 +102,7 @@ module Test_optional_variant = struct
 
 end
 [%%expect{|
-Line _, characters 14-19:
+Line _, characters _-_:
 Error: This variant expression is expected to have type t
        The constructor BAD_4 does not belong to type t
 |}]
@@ -119,7 +119,7 @@ module Test_nested_error = struct
   [%% import "test_imported/error/a.ml" ]
 end
 [%%expect{|
-Line _, characters 4-9:
+Line _, characters _-_:
 Error: nested error
 |}]
 
@@ -135,47 +135,47 @@ module Test_import_config = struct
   let x = "BAD"
   [%% endif]
 
-  let _ = printf "%s" x
+  let () = printf "%s" x
 end
 [%%expect{| OK |}]
 
 module Test_order = struct
   open Core
 
-  let _ = printf "%s" "a"
-  let _ = printf "%s" "b"
+  let () = printf "%s" "a"
+  let () = printf "%s" "b"
 
   [%% if true ]
-   let _ = printf "%s" "c"
-   let _ = printf "%s" "d"
+   let () = printf "%s" "c"
+   let () = printf "%s" "d"
    [%% define ABC]
-   let _ = printf "%s" "e"
-   let _ = printf "%s" "f"
+   let () = printf "%s" "e"
+   let () = printf "%s" "f"
   [%% endif ]
 
   [%% if false ]
   [%% else ]
-   let _ = printf "%s" "g"
-   let _ = printf "%s" "h"
+   let () = printf "%s" "g"
+   let () = printf "%s" "h"
    [%% define ABC]
-   let _ = printf "%s" "i"
-   let _ = printf "%s" "j"
+   let () = printf "%s" "i"
+   let () = printf "%s" "j"
   [%% endif ]
 
   [%% if false ]
   [%% elif true ]
-   let _ = printf "%s" "k"
-   let _ = printf "%s" "l"
+   let () = printf "%s" "k"
+   let () = printf "%s" "l"
    [%% define ABC]
-   let _ = printf "%s" "m"
-   let _ = printf "%s" "n"
+   let () = printf "%s" "m"
+   let () = printf "%s" "n"
   [%% endif ]
 
-  let _ = printf "%s" "o"
-  let _ = printf "%s" "p"
+  let () = printf "%s" "o"
+  let () = printf "%s" "p"
   [%% define ABC]
-  let _ = printf "%s" "q"
-  let _ = printf "%s" "r"
+  let () = printf "%s" "q"
+  let () = printf "%s" "r"
 end
 [%%expect{| abcdefghijklmnopqr |}]
 
@@ -183,7 +183,7 @@ module Test_show = struct
   open Core
 
   [%% if (show (3+3*3)) > 0]
-   let _ = printf "%s" "OK";
+   let () = printf "%s" "OK";
   [%% endif ]
 
   [%% define x "OK"]
@@ -211,7 +211,7 @@ module Test_optional_match = struct
   | OK2 of string * int [@if defined FOO]
   | BAD of int [@if defined BAR]
 
-  let _ = match ((OK2 ("OK", 2)): t) with
+  let () = match ((OK2 ("OK", 2)): t) with
   | OK1 s -> printf "%s" s
   | OK2 (y,z) [@if defined FOO] -> printf "%s %i\n" y z
   | BAD _ [@if defined BAR] -> printf "This will cause error if not dropped %s" undefined_ident
@@ -221,7 +221,7 @@ module Test_optional_match = struct
    | OK2 _ -> "OK"
    | BAD _ [@if defined BAR] -> "BAD"
 
-  let _ = printf "%s" (f (OK1 "abc"))
+  let () = printf "%s" (f (OK1 "abc"))
 end
 [%%expect{|
 OK 2
@@ -283,7 +283,7 @@ module Test_scoping = struct
     module A = struct
       [%%define x "BAD1"]
       [%%ifdef x]
-        let _ = printf "%s" "OK2"
+        let () = printf "%s" "OK2"
       [%%endif]
     end
     [%%define y (show x)]

--- a/test/test_imported/error/c.ml
+++ b/test/test_imported/error/c.ml
@@ -1,1 +1,1 @@
-[%% error "nested error" ]
+[%% optcomp.error "nested error" ]


### PR DESCRIPTION
For OCaml 4.11.2, merge tag `v0.13.0` from Jane Street repository.

Tested by building Mina with OCaml 4.11.2.
